### PR TITLE
Allow using lower case ldap ID

### DIFF
--- a/ldap-id-uppercase/ldap-id-uppercase.js
+++ b/ldap-id-uppercase/ldap-id-uppercase.js
@@ -1,6 +1,18 @@
-var ldap_id_uppercase = "";
-user.getAttributeStream("LDAP_ID").forEach(function(ldap_id) {
-  ldap_id_uppercase = ldap_id.toUpperCase();
-  print("Upper Case LDAP_ID: " + ldap_id_uppercase)
+var converted_ldap_id = "";
+var lower_case_ldap_id = false;
+
+user.getAttributeStream("lower_case_ldap_id").forEach(function(lower_case_ldap_id_attribute) {
+  if (lower_case_ldap_id_attribute == "true") {
+    lower_case_ldap_id = true;
+  }
 });
-exports = ldap_id_uppercase;
+
+user.getAttributeStream("LDAP_ID").forEach(function(ldap_id) {
+  if (lower_case_ldap_id) {
+    converted_ldap_id = ldap_id.toLowerCase();
+  } else {
+    converted_ldap_id = ldap_id.toUpperCase();
+  }
+  print("Upper Case LDAP_ID: " + converted_ldap_id)
+});
+exports = converted_ldap_id;


### PR DESCRIPTION
Decide on a user attribute named `lower_case_ldap_id` if an ID should be converted to lower or upper case.